### PR TITLE
turn off rules conflicting with prettier

### DIFF
--- a/portfolio/.eslintrc.json
+++ b/portfolio/.eslintrc.json
@@ -6,7 +6,7 @@
     "browser": true,
     "es6": true
   },
-  "extends": ["eslint:recommended", "google"],
+  "extends": ["eslint:recommended", "google", "prettier"],
   "rules": {
     "require-jsdoc": "off",
     "valid-jsdoc": "off",

--- a/portfolio/package.json
+++ b/portfolio/package.json
@@ -3,5 +3,8 @@
     "eslint-config-google": "^0.14.0",
     "eslint": "^7.2.0",
     "prettier": "^2.0.5"
+  },
+  "dependencies": {
+    "eslint-config-prettier": "^6.11.0"
   }
 }


### PR DESCRIPTION
Turns off all rules from eslint that might conflict with prettier. See [eslint-config-prettier](https://github.com/prettier/eslint-config-prettier)